### PR TITLE
feat(game): add virtual mobile keyboard

### DIFF
--- a/Content/actions.js
+++ b/Content/actions.js
@@ -77,9 +77,9 @@ window.Actions = {
       { type: "stateChange", damage: 10 }
     ]
   },
-  confidentStatus: {
-    name: "Tomato Squeeze",
-    description: "Applies the confident status",
+  confident: {
+    name: "Feeling confident!",
+    description: "Emergency confidence boost",
     targetType: "friendly",
     success: [
       { type: "textMessage", text: "{CASTER} uses {ACTION}!"},
@@ -132,9 +132,9 @@ window.Actions = {
     description: "Tastes better when hungry",
     targetType: "friendly",
     success: [
-      { type:"textMessage", text: "{CASTER} finds a {ACTION} in their bag!", },
+      { type:"textMessage", text: `{HERO} finds a {ACTION} in their bag!` },
       { type:"stateChange", recover: 10, },
-      { type:"textMessage", text: "{CASTER} recovers HP!", },
+      { type:"textMessage", text: `{HERO} recovers HP!`, },
     ]
   },
 }

--- a/Content/actions.js
+++ b/Content/actions.js
@@ -104,7 +104,7 @@ window.Actions = {
     description: "No longer has any idea what's going on!",
     success: [
       { type: "textMessage", character: CHARACTERS[MRS_T], text: "Hello, dear. Sorry, I did not see you there!"},
-      { type: "stateChange", damage: 1 }
+      { type: "stateChange", damage: 3 }
     ]
   },
   disoriented2: {

--- a/Content/skills.js
+++ b/Content/skills.js
@@ -42,7 +42,7 @@ window.Skills = {
     type: SkillTypes.normal,
     src: "/images/characters/skills/s001.png",
     icon: "/images/icons/spicy.png",
-    actions: [ "confidentStatus", "sleepyStatus", "damage1" ],
+    actions: [ "confident", "sleepy", "damage1" ],
   },
   "s002": {
     name: "Bacon Brigade",
@@ -50,7 +50,7 @@ window.Skills = {
     type: SkillTypes.normal,
     src: "/images/characters/skills/s002.png",
     icon: "/images/icons/spicy.png",
-    actions: [ "damage1", "confidentStatus", "sleepyStatus" ],
+    actions: [ "damage1", "confident", "sleepy" ],
   },
   "v001": {
     name: "Call Me Kale",

--- a/Question/Combatant.js
+++ b/Question/Combatant.js
@@ -88,7 +88,7 @@ class Combatant {
       case "disoriented":
         return [
           { type: "textMessage", text: `${this.name} no longer has any idea what's going on!` },
-          { type: "stateChange", damage: 1 }
+          { type: "stateChange", damage: 3 }
         ]
       case "shocked": 
         return [

--- a/Question/QuestionEvent.js
+++ b/Question/QuestionEvent.js
@@ -9,6 +9,7 @@ class QuestionEvent {
       .replace("{CASTER}", this.event.caster?.name)
       .replace("{TARGET}", this.event.target?.name)
       .replace("{ACTION}", this.event.action?.name)
+      .replace("{HERO}", window.playerState.hero.your_name)
 
     const message = new TextMessage({
       text,

--- a/components/ChooseCharacter.js
+++ b/components/ChooseCharacter.js
@@ -36,7 +36,7 @@ class ChooseCharacter {
         <label for="he"><input type="radio" id="he" name="pronouns" value="he">He/his</label>
       </section>
       <section class="ChooseCharacter_name"> 
-        <label for="hero_name" >Enter your name:</label>
+        <label for="hero_name">Enter your name:</label>
         <input id="hero_name" name="your_name" value="YN">
       </section> 
       <button>OK</button>`

--- a/components/ChooseCharacter.js
+++ b/components/ChooseCharacter.js
@@ -39,8 +39,8 @@ class ChooseCharacter {
         <label for="hero_name">Enter your name:</label>
         <input id="hero_name" name="your_name" value="YN">
       </section> 
-      <button>OK</button>`
-    
+      <button id="ChooseCharacter_ok">OK</button>`
       this.parent.appendChild(this.chooseCharacterEl)
+      document.getElementById("ChooseCharacter_ok").focus()
   }
 }

--- a/components/DirectionInput.js
+++ b/components/DirectionInput.js
@@ -1,7 +1,6 @@
 class DirectionInput {
   constructor() {
-    this.heldDirections = [];
-
+    this.heldDirections = []
     this.map = {
       "ArrowUp": "up",
       "KeyW": "up",
@@ -15,24 +14,45 @@ class DirectionInput {
   }
 
   get direction() {
-    return this.heldDirections[0];
+    return this.heldDirections[0]
+  }
+
+  initMobile(target) {
+    target.element.addEventListener("touchstart", event => {
+      const dir = event.target.id
+      if (dir && this.heldDirections.indexOf(dir) === -1) {
+        this.heldDirections.unshift(dir)
+      }
+    })
+    target.element.addEventListener("touchend", event => {
+      const dir = event.target.id
+      const index = this.heldDirections.indexOf(dir)
+      if (index > -1) {
+        this.heldDirections.splice(index, 1)
+      }
+    })
+  }
+
+  initDesktop() {
+    document.addEventListener("keydown", event => {
+      const dir = this.map[event.code]
+      if (dir && this.heldDirections.indexOf(dir) === -1) {
+        this.heldDirections.unshift(dir)
+      }
+    })
+    document.addEventListener("keyup", event => {
+      const dir = this.map[event.code]
+      const index = this.heldDirections.indexOf(dir)
+      if (index > -1) {
+        this.heldDirections.splice(index, 1)
+      }
+    })
   }
 
   init() {
-    document.addEventListener("keydown", e => {
-      const dir = this.map[e.code];
-      if (dir && this.heldDirections.indexOf(dir) === -1) {
-        this.heldDirections.unshift(dir);
-      }
-    });
-    document.addEventListener("keyup", e => {
-      const dir = this.map[e.code];
-      const index = this.heldDirections.indexOf(dir);
-      if (index > -1) {
-        this.heldDirections.splice(index, 1);
-      }
-    })
-
+    if (window.playerState.mobileKeyboard) 
+      this.initMobile(window.playerState.mobileKeyboard)
+    else this.initDesktop()
   }
 
 }

--- a/components/GameObject.js
+++ b/components/GameObject.js
@@ -29,9 +29,7 @@ class GameObject {
     if (this.behaviorLoop.length === 0) return
 
     if (map.isCutscenePlaying) {
-      if (this.retryTimeout) {
-        clearTimeout(this.retryTimeout)
-      }
+      if (this.retryTimeout) clearTimeout(this.retryTimeout)
       this.retryTimeout = setTimeout(() => {
         this.doBehaviorEvent(map)
       }, 1000)

--- a/components/KeyPressListener.js
+++ b/components/KeyPressListener.js
@@ -1,27 +1,23 @@
 class KeyPressListener {
   constructor(keyCode, callback) {
-    let keySafe = true;
+    let keySafe = true
     this.keydownFunction = function(event) {
       if (event.code === keyCode) {
          if (keySafe) {
-            keySafe = false;
-            callback();
+            keySafe = false
+            callback()
          }  
       }
-   };
+   }
    this.keyupFunction = function(event) {
-      if (event.code === keyCode) {
-         keySafe = true;
-      }         
-   };
-   document.addEventListener("keydown", this.keydownFunction);
-   document.addEventListener("keyup", this.keyupFunction);
+      if (event.code === keyCode) keySafe = true
+   }
+   document.addEventListener("keydown", this.keydownFunction)
+   document.addEventListener("keyup", this.keyupFunction)
   }
 
   unbind() { 
-    document.removeEventListener("keydown", this.keydownFunction);
-    document.removeEventListener("keyup", this.keyupFunction);
+    document.removeEventListener("keydown", this.keydownFunction)
+    document.removeEventListener("keyup", this.keyupFunction)
   }
-
-
 }

--- a/components/KeyboardMenu.js
+++ b/components/KeyboardMenu.js
@@ -1,6 +1,6 @@
 class KeyboardMenu {
   constructor(config={}, hideDescription) {
-    this.options = [] //set by updater method
+    this.options = []
     this.up = null
     this.down = null
     this.prevFocus = null

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -1,5 +1,7 @@
 class MobileKeyboard {
-  constructor(){}
+  constructor() {
+    this.container = document.querySelector(".game-container")
+  }
   createElement() {
     this.element = document.createElement("div")
     this.element.classList.add("MobileKeyboard")
@@ -9,7 +11,13 @@ class MobileKeyboard {
     <button class="MobileKey up">➤</button>
     <button class="MobileKey down">➤</button>
     `
-    document.querySelector(".game-container").appendChild(this.element)
+    this.show()
+  }
+  hide() {
+    this.element.remove()
+  }
+  show() {
+    this.container.appendChild(this.element)
   }
   init() {
     this.createElement()

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -6,10 +6,10 @@ class MobileKeyboard {
     this.element = document.createElement("div")
     this.element.classList.add("MobileKeyboard")
     this.element.innerHTML = `
-    <button class="MobileKey left">➤</button>
-    <button class="MobileKey right">➤</button>
-    <button class="MobileKey up">➤</button>
-    <button class="MobileKey down">➤</button>
+    <button id="left" class="MobileKey left">➤</button>
+    <button id="right" class="MobileKey right">➤</button>
+    <button id="up" class="MobileKey up">➤</button>
+    <button id="down" class="MobileKey down">➤</button>
     `
     this.show()
   }

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -21,6 +21,7 @@ class MobileKeyboard {
   }
   init() {
     document.querySelector(".how-to-play").remove()
+    this.container.classList.add("mobile")
     this.createElement()
   }
 }

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -1,0 +1,17 @@
+class MobileKeyboard {
+  constructor(){}
+  createElement() {
+    this.element = document.createElement("div")
+    this.element.classList.add("MobileKeyboard")
+    this.element.innerHTML = `
+    <button class="MobileKey left">➤</button>
+    <button class="MobileKey right">➤</button>
+    <button class="MobileKey up">➤</button>
+    <button class="MobileKey down">➤</button>
+    `
+    document.querySelector(".game-container").appendChild(this.element)
+  }
+  init() {
+    this.createElement()
+  }
+}

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -5,6 +5,7 @@ class MobileKeyboard {
   createElement() {
     const escButton = document.createElement("button")
     escButton.classList.add("EscButton")
+    escButton.id = "escape"
     this.container.appendChild(escButton)
     escButton.innerHTML = "settings"
 

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -34,7 +34,7 @@ class MobileKeyboard {
   }
   init() {
     document.querySelector(".how-to-play").remove()
-    this.container.classList.add("mobile")
+    this.container.id = "mobile"
     this.createElement()
   }
 }

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -8,6 +8,7 @@ class MobileKeyboard {
     this.element.innerHTML = `
     <button id="left" class="MobileKey left">➤</button>
     <button id="right" class="MobileKey right">➤</button>
+    <button id="enter" class="MobileKey enter">ok</button>
     <button id="up" class="MobileKey up">➤</button>
     <button id="down" class="MobileKey down">➤</button>
     `

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -3,28 +3,34 @@ class MobileKeyboard {
     this.container = document.querySelector(".game-container")
   }
   createElement() {
-    const escButton = document.createElement("button")
-    escButton.classList.add("EscButton")
-    escButton.id = "escape"
-    this.container.appendChild(escButton)
-    escButton.innerHTML = "settings"
+    this.escButton = document.createElement("button")
+    this.escButton.classList.add("EscButton")
+    this.escButton.id = "escape"
+    this.container.appendChild(this.escButton)
+    this.escButton.innerHTML = "settings"
+
+    this.okButton = document.createElement("button")
+    this.okButton.classList.add("MobileKey", "enter")
+    this.okButton.id = "enter"
+    this.okButton.innerHTML = "ok"
 
     this.element = document.createElement("div")
     this.element.classList.add("MobileKeyboard")
     this.element.innerHTML = `
     <button id="left" class="MobileKey left">➤</button>
     <button id="right" class="MobileKey right">➤</button>
-    <button id="enter" class="MobileKey enter">ok</button>
     <button id="up" class="MobileKey up">➤</button>
-    <button id="down" class="MobileKey down">➤</button>
-    `
+    <button id="down" class="MobileKey down">➤</button>`
+    this.element.appendChild(this.okButton)
     this.show()
   }
   hide() {
-    //this.element.remove()
+    this.element.remove()
+    this.escButton.remove()
   }
   show() {
     this.container.appendChild(this.element)
+    this.container.appendChild(this.escButton)
   }
   init() {
     document.querySelector(".how-to-play").remove()

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -20,6 +20,7 @@ class MobileKeyboard {
     this.container.appendChild(this.element)
   }
   init() {
+    document.querySelector(".how-to-play").remove()
     this.createElement()
   }
 }

--- a/components/MobileKeyboard.js
+++ b/components/MobileKeyboard.js
@@ -3,6 +3,11 @@ class MobileKeyboard {
     this.container = document.querySelector(".game-container")
   }
   createElement() {
+    const escButton = document.createElement("button")
+    escButton.classList.add("EscButton")
+    this.container.appendChild(escButton)
+    escButton.innerHTML = "settings"
+
     this.element = document.createElement("div")
     this.element.classList.add("MobileKeyboard")
     this.element.innerHTML = `
@@ -15,7 +20,7 @@ class MobileKeyboard {
     this.show()
   }
   hide() {
-    this.element.remove()
+    //this.element.remove()
   }
   show() {
     this.container.appendChild(this.element)

--- a/components/Overworld.js
+++ b/components/Overworld.js
@@ -33,17 +33,37 @@ class Overworld {
     step()
  }
 
- bindActionInput() {
-   new KeyPressListener("Enter", () => {
-     this.map.checkForActionCutscene()
-   })
-   new KeyPressListener("Escape", () => {
-     if (!this.map.isCutscenePlaying) {
+ bindDesktopActionInput() {
+  new KeyPressListener("Enter", () => {
+    this.map.checkForActionCutscene()
+  })
+  new KeyPressListener("Escape", () => {
+    if (!this.map.isCutscenePlaying) {
+     this.map.startCutscene([
+       { type: "pause" }
+     ])
+    }
+  })
+ }
+
+ bindMobileActionInput() {
+  const enterKey = document.getElementById("enter")
+  const escapeKey = document.getElementById("escape")
+  enterKey.addEventListener("touchstart", () => {
+    this.map.checkForActionCutscene()
+  })
+  escapeKey.addEventListener("touchstart", () => {
+    if (!this.map.isCutscenePlaying) {
       this.map.startCutscene([
         { type: "pause" }
       ])
      }
-   })
+  })
+ }
+
+ bindActionInput() {
+  if (window.playerState.mobileKeyboard) this.bindMobileActionInput()
+  else this.bindDesktopActionInput()
  }
 
  bindHeroPositionCheck() {

--- a/components/Overworld.js
+++ b/components/Overworld.js
@@ -47,12 +47,11 @@ class Overworld {
  }
 
  bindMobileActionInput() {
-  const enterKey = document.getElementById("enter")
-  const escapeKey = document.getElementById("escape")
-  enterKey.addEventListener("touchstart", () => {
+  const { escButton, okButton }  = window.playerState.mobileKeyboard
+  okButton.addEventListener("touchstart", () => {
     this.map.checkForActionCutscene()
   })
-  escapeKey.addEventListener("touchstart", () => {
+  escButton.addEventListener("touchstart", () => {
     if (!this.map.isCutscenePlaying) {
       this.map.startCutscene([
         { type: "pause" }

--- a/components/OverworldEvent.js
+++ b/components/OverworldEvent.js
@@ -65,6 +65,7 @@ class OverworldEvent {
       emotion: this.event.emotion,
       cb: this.event.cb,
       effect: this.event.effect,
+      effectType: this.event.effectType,
       onComplete: () => resolve()
     })
     message.init( document.querySelector(".game-container") )

--- a/components/OverworldEvent.js
+++ b/components/OverworldEvent.js
@@ -52,7 +52,6 @@ class OverworldEvent {
   }
 
   textMessage(resolve) {
-
     if (this.event.faceHero) {
       const obj = this.map.gameObjects[this.event.faceHero]
       obj.direction = utils.oppositeDirection(this.map.gameObjects["hero"].direction)
@@ -99,6 +98,7 @@ class OverworldEvent {
   }
 
   question(resolve) {
+    document.querySelector(".TextMessage")?.remove()
     const question = new Question({
       enemy: this.event.enemy,
       arena: this.event.arena || null,
@@ -107,7 +107,6 @@ class OverworldEvent {
       }
     })
     question.init(document.querySelector(".game-container"))
-
   }
 
   pause(resolve) {

--- a/components/OverworldMap.js
+++ b/components/OverworldMap.js
@@ -109,6 +109,7 @@ class OverworldMap {
     if (isSeenScene.length) return
 
     this.isCutscenePlaying = true
+    
 
     for (let i=0; i<events.length; i++) {
       const eventHandler = new OverworldEvent({

--- a/components/OverworldMap.js
+++ b/components/OverworldMap.js
@@ -109,7 +109,8 @@ class OverworldMap {
     if (isSeenScene.length) return
 
     this.isCutscenePlaying = true
-    window.playerState.mobileKeyboard.hide()
+    const mobileKeyboard = window.playerState.mobileKeyboard
+    if (mobileKeyboard) mobileKeyboard.hide()
     
 
     for (let i=0; i<events.length; i++) {
@@ -123,7 +124,7 @@ class OverworldMap {
       }
     }
     this.isCutscenePlaying = false
-    window.playerState.mobileKeyboard.show()
+    mobileKeyboard.show()
   }
 
   checkForActionCutscene() {
@@ -193,6 +194,7 @@ window.OverworldMaps = {
         events: [
           { type: "textMessage", text: "February, 29. 1992.", effect: "intro" },
           { type: "textMessage", text: "Kaliningrad, Russia.", effect: "intro" },
+          { type: "textMessage", text: "You stay late in the library writing your thesis.", effect: "intro", effectType: "text" },
           { type: "externalEffect", kind: "darkMax", time: 5000},
           { type: "stand", who: HERO, direction: "up", time: 200},
           { type: "stand", who: HERO, direction: "left", time: 200},

--- a/components/OverworldMap.js
+++ b/components/OverworldMap.js
@@ -109,6 +109,7 @@ class OverworldMap {
     if (isSeenScene.length) return
 
     this.isCutscenePlaying = true
+    window.playerState.mobileKeyboard.hide()
     
 
     for (let i=0; i<events.length; i++) {
@@ -122,6 +123,7 @@ class OverworldMap {
       }
     }
     this.isCutscenePlaying = false
+    window.playerState.mobileKeyboard.show()
   }
 
   checkForActionCutscene() {

--- a/components/TextMessage.js
+++ b/components/TextMessage.js
@@ -3,13 +3,13 @@ const HERR_DOKTOR_PHRASES = []
 const getRandomPhrase = (character) => {
   switch (character) {
     case [HERR_DOKTOR]: {
-      return HERR_DOKTOR_PHRASES[Math.floor(Math.random() * (HERR_DOKTOR_PHRASES.length))] 
+      return HERR_DOKTOR_PHRASES[Math.floor(Math.random() * (HERR_DOKTOR_PHRASES.length))]
     }
   }
 }
 
 class TextMessage {
-  constructor({ text, character, onComplete, sayRandom, emotion, cb, effect }) {
+  constructor({ text, character, onComplete, sayRandom, emotion, cb, effect, effectType }) {
     this.text = text
     this.character = character
     this.onComplete = onComplete
@@ -18,6 +18,7 @@ class TextMessage {
     this.emotion = emotion
     this.cb = cb
     this.effect = effect
+    this.effectType = effectType
   }
 
   createElement() {
@@ -28,6 +29,7 @@ class TextMessage {
       this.effectParent = document.createElement("div")
       this.effectParent.classList.add("TextMessage_effect", this.effect)
     }
+    if (this.effectType) this.effectParent.classList.add(this.effectType)
 
     this.element.innerHTML = (`
       <p class="TextMessage_p"></p>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link href="/styles/ExternalEffect.css" type="text/css" rel="stylesheet">
     <link href="/styles/SceneTransition.css" type="text/css" rel="stylesheet">
     <link href="/styles/KeyboardMenu.css" type="text/css" rel="stylesheet">
+    <link href="/styles/MobileKeyboard.css" type="text/css" rel="stylesheet">
     <link href="/styles/Hud.css" type="text/css" rel="stylesheet">
     <link href="/styles/TitleScreen.css" type="text/css" rel="stylesheet">
     <link href="/styles/Question.css" type="text/css" rel="stylesheet">
@@ -41,6 +42,7 @@
     <script src="/components/RevealingText.js"></script>
     <script src="/components/SceneTransition.js"></script>
     <script src="/components/KeyboardMenu.js"></script>
+    <script src="/components/MobileKeyboard.js"></script>
     <script src="/components/Hud.js"></script>
     <script src="/components/Prompt.js"></script>
     <script src="/components/PauseMenu.js"></script>

--- a/init.js
+++ b/init.js
@@ -9,6 +9,8 @@
   if (playerHasNoKeyboard) {
     const mobileKeyboard = new MobileKeyboard({})
     mobileKeyboard.init()
+    mobileKeyboard.hide()
+    window.playerState.mobileKeyboard = mobileKeyboard
   }
 
   const overworld = new Overworld({

--- a/init.js
+++ b/init.js
@@ -1,15 +1,14 @@
 (function () {
-
-  if (navigator.userAgent.match(/Android/i)
+  const playerHasNoKeyboard = navigator.userAgent.match(/Android/i)
   || navigator.userAgent.match(/webOS/i)
   || navigator.userAgent.match(/iPhone/i)
   || navigator.userAgent.match(/iPad/i)
   || navigator.userAgent.match(/iPod/i)
   || navigator.userAgent.match(/BlackBerry/i)
-  || navigator.userAgent.match(/Windows Phone/i)) {
-    const bodyElement = document.querySelector("body")
-    bodyElement.classList.add("device-error")
-    return bodyElement.innerHTML = `<span class="device-error_message">Sorry, you need a keyboard to play this game (yet).</span>`
+  || navigator.userAgent.match(/Windows Phone/i)
+  if (playerHasNoKeyboard) {
+    const mobileKeyboard = new MobileKeyboard({})
+    mobileKeyboard.init()
   }
 
   const overworld = new Overworld({

--- a/styles/ChooseCharacter.css
+++ b/styles/ChooseCharacter.css
@@ -123,7 +123,7 @@ input[type="radio"] {
   color: currentColor;
   width: 1.15em;
   height: 1.15em;
-  border: 0.15em solid #484040;
+  border: 0.15em solid var(--radio-border);
   border-radius: 50%;
   transform: translateY(-0.075em);
   display: grid;

--- a/styles/MobileKeyboard.css
+++ b/styles/MobileKeyboard.css
@@ -10,9 +10,6 @@
 }
 .MobileKey {
   position: absolute;
-  border: 1px solid var(--radio-border);
-  border-radius: 2px;
-  outline: none;
   color: black;
 }
 .MobileKey.left {
@@ -21,7 +18,7 @@
   transform: rotate(180deg);
 }
 .MobileKey.right {
-  left: 60%;
+  left: 65%;
   top: 35%;
 }
 .MobileKey.up {

--- a/styles/MobileKeyboard.css
+++ b/styles/MobileKeyboard.css
@@ -1,0 +1,22 @@
+.MobileKeyboard {
+  position: absolute;
+  z-index: 10;
+  top: 50%;
+  right: 10px;
+  background-color: var(--keys-menu);
+  width: 64px;
+  height: 64px;
+  border-radius: 50px;
+}
+.MobileKey {
+  position: absolute;
+  top: 0;
+}
+.MobileKey.left {
+  left: 25%;
+  transform: rotate(270deg);
+}
+.MobileKey.left {
+  left: 25%;
+  transform: rotate(270deg);
+}

--- a/styles/MobileKeyboard.css
+++ b/styles/MobileKeyboard.css
@@ -35,3 +35,17 @@
   left: 26%;
   top: 35%;
 }
+
+.EscButton {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 5;
+  font-size: 8px;
+  outline: none;
+  border:none;
+  padding: 4px 6px;
+  background-color: var(--keys-menu);
+  color: var(--text-message-action);
+  opacity: 0.7;
+}

--- a/styles/MobileKeyboard.css
+++ b/styles/MobileKeyboard.css
@@ -13,21 +13,25 @@
   color: black;
 }
 .MobileKey.left {
-  left: -10%;
+  left: -20%;
   top: 35%;
   transform: rotate(180deg);
 }
 .MobileKey.right {
-  left: 65%;
+  left: 75%;
   top: 35%;
 }
 .MobileKey.up {
   left: 27%;
-  top: 0;
+  top: -10%;
   transform: rotate(270deg);
 }
 .MobileKey.down {
   left: 27%;
-  top: 70%;
+  top: 80%;
   transform: rotate(90deg);
+}
+.MobileKey.enter {
+  left: 26%;
+  top: 35%;
 }

--- a/styles/MobileKeyboard.css
+++ b/styles/MobileKeyboard.css
@@ -38,8 +38,9 @@
 
 .EscButton {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 11px;
+  right: -11px;
+  transform: rotate(90deg);
   z-index: 5;
   font-size: 8px;
   outline: none;

--- a/styles/MobileKeyboard.css
+++ b/styles/MobileKeyboard.css
@@ -10,6 +10,10 @@
 }
 .MobileKey {
   position: absolute;
+  border: 1px solid var(--radio-border);
+  border-radius: 2px;
+  outline: none;
+  color: black;
 }
 .MobileKey.left {
   left: -10%;
@@ -17,7 +21,7 @@
   transform: rotate(180deg);
 }
 .MobileKey.right {
-  left: 65%;
+  left: 60%;
   top: 35%;
 }
 .MobileKey.up {

--- a/styles/MobileKeyboard.css
+++ b/styles/MobileKeyboard.css
@@ -1,8 +1,8 @@
 .MobileKeyboard {
   position: absolute;
   z-index: 10;
-  top: 50%;
-  right: 10px;
+  top: 60%;
+  right: 0;
   background-color: var(--keys-menu);
   width: 64px;
   height: 64px;
@@ -10,13 +10,23 @@
 }
 .MobileKey {
   position: absolute;
+}
+.MobileKey.left {
+  left: -10%;
+  top: 35%;
+  transform: rotate(180deg);
+}
+.MobileKey.right {
+  left: 65%;
+  top: 35%;
+}
+.MobileKey.up {
+  left: 27%;
   top: 0;
-}
-.MobileKey.left {
-  left: 25%;
   transform: rotate(270deg);
 }
-.MobileKey.left {
-  left: 25%;
-  transform: rotate(270deg);
+.MobileKey.down {
+  left: 27%;
+  top: 70%;
+  transform: rotate(90deg);
 }

--- a/styles/TextMessage.css
+++ b/styles/TextMessage.css
@@ -23,7 +23,11 @@
   width: 54%;
   left: 22%;
   border: none;
-  padding: 10px 40px;
+  text-align: center;
+  padding: 10px 10px;
+}
+.TextMessage_effect.intro.text > .TextMessage {
+  padding: 5px 10px;
 }
 
 .TextMessage_p {

--- a/styles/global.css
+++ b/styles/global.css
@@ -55,7 +55,7 @@ input:focus-visible{
   .game-container {
     transform: scale(2.5) translateY(40%);
   }
-  .game-container.mobile {
+  .game-container#mobile {
     transform: scale(2) translateY(30%);
   }
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -42,15 +42,21 @@ body {
   transform: scale(3) translateY(36%);
 }
 
-@media screen and (max-width: 1100px){
+@media screen and (min-width: 901px) and (max-width: 1100px) {
   .game-container {
     transform: scale(2.5) translateY(40%);
   }
 }
 
-@media screen and (max-width: 900px){
+@media screen and (min-width: 700px) and (max-width: 900px) {
   .game-container {
     transform: scale(2) translateY(50%);
+  }
+}
+
+@media screen and (max-width: 850px) and (max-height: 500px) {
+  .game-container {
+    transform: scale(2.1) translateY(29%);
   }
 }
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -52,12 +52,10 @@ input:focus-visible{
 
 @media screen and (max-width: 1100px) {
   .game-container {
-    transform: scale(2) translateY(40%);
+    transform: scale(2.5) translateY(40%);
+  }
+  .game-container.mobile {
+    transform: scale(2) translateY(30%);
   }
 }
 
-@media screen and (max-width: 900px) {
-  .game-container {
-    transform: scale(2) translateY(40%);
-  }
-}

--- a/styles/global.css
+++ b/styles/global.css
@@ -48,15 +48,9 @@ body {
   }
 }
 
-@media screen and (min-width: 700px) and (max-width: 900px) {
+@media screen and (max-width: 900px) {
   .game-container {
-    transform: scale(2) translateY(50%);
-  }
-}
-
-@media screen and (max-width: 850px) and (max-height: 500px) {
-  .game-container {
-    transform: scale(2.1) translateY(29%);
+    transform: scale(2) translateY(40%);
   }
 }
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -42,9 +42,17 @@ body {
   transform: scale(3) translateY(36%);
 }
 
-@media screen and (min-width: 901px) and (max-width: 1100px) {
+.game-container canvas {
+  image-rendering: pixelated;
+}
+
+input:focus-visible{
+  outline: 1px solid var(--menu-border-color);
+}
+
+@media screen and (max-width: 1100px) {
   .game-container {
-    transform: scale(2.5) translateY(40%);
+    transform: scale(2) translateY(40%);
   }
 }
 
@@ -52,12 +60,4 @@ body {
   .game-container {
     transform: scale(2) translateY(40%);
   }
-}
-
-.game-container canvas {
-  image-rendering: pixelated;
-}
-
-input:focus-visible{
-  outline: 1px solid var(--menu-border-color);
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,6 +1,7 @@
 :root {
   --main: #050301;
   --border-color: #291D4D;
+  --radio-border: #484040;
   --dialog-background: #5e3e17;
   --menu-background: #5e3e17;
   --keys-menu: rgba(94,62,23,0.4);

--- a/styles/global.css
+++ b/styles/global.css
@@ -3,6 +3,7 @@
   --border-color: #291D4D;
   --dialog-background: #5e3e17;
   --menu-background: #5e3e17;
+  --keys-menu: rgba(94,62,23,0.4);
   --menu-border-color: rgba(255,215,0,1);
   --text-message-action: rgba(255,215,0,1);
   --button-action: rgba(255,215,0,0.8);
@@ -55,21 +56,6 @@ body {
 
 .game-container canvas {
   image-rendering: pixelated;
-}
-
-
-.device-error {
-  width: 100vw;
-  height: 100vh;
-  overflow: hidden;
-}
-
-.device-error_message {
-  color: var(--text-message-action);
-  font-size: 24px;
-  padding: 24px;
-  display: block;
-  width: 280px;
 }
 
 input:focus-visible{


### PR DESCRIPTION
### What
Users on mobiles can play the game using the virtual keyboard.

### How
<img width="577" alt="Screenshot 2023-08-14 at 17 25 33" src="https://github.com/dariadia/library-rpg/assets/42477973/7ecff11b-6f7e-45a6-b7db-eca08a532280">

- add hovering "keyboard-like" block with arrows and "ok" (for Enter);
- set this block to show on "play" mode and hide on "cutscene playing";
- style this block;
- add a separate block to imitate the "esc" popup menu (save option);
- add all related event listeners and dismiss the unrelated elements (e.g. the "how-to-play" which says to use keyboard buttons)